### PR TITLE
Add methods to handle video of tests

### DIFF
--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -28,7 +28,9 @@ var paths = {
   har: 'export.php',
   waterfall: 'waterfall.php',
   thumbnail: 'thumbnail.php',
-  cancel: 'cancelTest.php'
+  cancel: 'cancelTest.php',
+  videoCreation: 'video/create.php',
+  videoView: 'video/view.php'
 };
 
 var filenames = {
@@ -577,6 +579,35 @@ function listen(local, callback) {
   return server.listen.call(this, local, callback);
 }
 
+function getEmbedVideoPlayer(id, options, callback) {
+  var params = {
+    embed: 1,
+    id: id
+  };
+
+  options.args = options.args || {
+    type: 'text/html',
+    encoding: options.dataURI ? 'utf8' : options.encoding
+  };
+
+  options.parser = function (data) {
+    return data.toString();
+  };
+
+  api.call(this, paths.videoView, callback, params, options);
+}
+
+function createVideo(tests, options, callback) {
+  //prefer the json format because the xml format is buggy with wpt 2.11
+  var params = {
+    tests: tests,
+    f: 'json',
+    end: options.end || 'visual'
+  };
+
+  api.call(this, paths.videoCreation, callback, params, options);
+}
+
 // WPT constructor
 function WebPageTest(server, key) {
   if (!(this instanceof WebPageTest)) {
@@ -620,6 +651,8 @@ WebPageTest.prototype = {
   getTestInfo: getTestInfo,
   getWaterfallImage: getWaterfallImage,
   getScreenshotImage: getScreenshotImage,
+  getEmbedVideoPlayer: getEmbedVideoPlayer,
+  createVideo: createVideo,
   scriptToString: WebPageTest.scriptToString,
   listen: listen,
 

--- a/test/dryrun-test.js
+++ b/test/dryrun-test.js
@@ -356,5 +356,20 @@ describe('Dry Run', function() {
       });
     });
 
+    it('create a video', function (done) {
+      wpt.createVideo('130416_YS_KD4-r:3-c:1,130416_W6_KEE-r:8-c:1', {dryRun: true}, function (err, data) {
+        if (err) throw err;
+        assert.equal(data.url, wptServer + 'video/create.php?tests=130416_YS_KD4-r%3A3-c%3A1%2C130416_W6_KEE-r%3A8-c%3A1&f=json&end=visual');
+        done();
+      });
+    });
+
+    it('get the url of an embedded video', function (done) {
+      wpt.getEmbedVideoPlayer('130416_36ed6e37013655a14b2b857cdccec99db72adcaa', {dryRun: true}, function (err, data) {
+        if (err) throw err;
+        assert.equal(data.url, wptServer + 'video/view.php?embed=1&id=130416_36ed6e37013655a14b2b857cdccec99db72adcaa');
+        done();
+      });
+    });
   });
 });

--- a/test/fixtures/objects/createVideo.json
+++ b/test/fixtures/objects/createVideo.json
@@ -1,0 +1,9 @@
+{
+   "statusCode":200,
+   "statusText":"Ok",
+   "data":{
+      "videoId":"130416_36ed6e37013655a14b2b857cdccec99db72adcaa",
+      "jsonUrl":"http:\/\/www.webpagetest.org\/video\/view.php?f=json&id=130416_36ed6e37013655a14b2b857cdccec99db72adcaa",
+      "userUrl":"http:\/\/www.webpagetest.org\/video\/view.php?id=130416_36ed6e37013655a14b2b857cdccec99db72adcaa"
+   }
+}

--- a/test/fixtures/objects/embeddedVideoPlayer.html
+++ b/test/fixtures/objects/embeddedVideoPlayer.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script type="text/javascript">var NREUMQ=NREUMQ||[];NREUMQ.push(["mark","firstbyte",new Date().getTime()]);</script>
+<title>WebPagetest - Visual Comparison - Apr 30, 2013 : , </title>
+                        <link rel="stylesheet" href="/video/video-js.3.2.0/video-js.min.css" type="text/css">
+        <style type="text/css">
+            div.content
+            {
+                text-align:center;
+                background-color: black;
+                color: white;
+                font-family: arial,sans-serif
+            }
+            .link
+            {
+                text-decoration: none;
+                color: white;
+            }
+            #player
+            {
+                margin-left: auto;
+                margin-right: auto;
+            }
+            #location {
+                text-align: left;
+                padding: 5px;
+                width: 100%;
+            }
+            .vjs-default-skin .vjs-controls {height: 0;}
+            .vjs-default-skin .vjs-mute-control {display: none;}
+            .vjs-default-skin .vjs-volume-control {display: none;}
+            body {background-color: black; margin:0; padding: 0;}        </style>
+        <script type="text/javascript" src="/video/video-js.3.2.0/video.min.js"></script>
+    </head>
+    <body>
+        <div class="page">
+            <script>
+_V_.options.techOrder = ['flash', 'html5'];
+_V_.options.flash.swf = '/video/player/flowplayer-3.2.16.swf';
+_V_.options.flash.flashVars = {config:"{'clip':{'scaling':'fit'},'plugins':{'controls':{'volume':false,'mute':false,'stop':true,'tooltips':{'buttons':true,'fullscreen':'Enter fullscreen mode'}}},'canvas':{'backgroundColor':'#000000','backgroundGradient':'none'},'playlist':[{'url':'/results/video/13/04/16/36ed6e37013655a14b2b857cdccec99db72adcaa/video.png'},{'url':'/results/video/13/04/16/36ed6e37013655a14b2b857cdccec99db72adcaa/video.mp4','autoPlay':false,'autoBuffering':false}]}"};
+_V_.options.flash.params = {
+                       allowfullscreen: 'true',
+                       wmode: 'transparent',
+                       allowscriptaccess: 'always'
+                   };
+                   _V_.options.flash.attributes={};
+</script>
+<video id="player" class="video-js vjs-default-skin" controls
+                  preload="auto" width="816" height="384" poster="/results/video/13/04/16/36ed6e37013655a14b2b857cdccec99db72adcaa/video.png"data-setup="{}">
+                    <source src="/results/video/13/04/16/36ed6e37013655a14b2b857cdccec99db72adcaa/video.mp4" type='video/mp4'>
+                </video>
+                    </div>
+    <script type="text/javascript">if(!NREUMQ.f){NREUMQ.f=function(){NREUMQ.push(["load",new Date().getTime()]);var e=document.createElement("script");e.type="text/javascript";e.src=(("http:"===document.location.protocol)?"http:":"https:")+"//"+"d1ros97qkrwjf5.cloudfront.net/42/eum/rum.js";document.body.appendChild(e);if(NREUMQ.a)NREUMQ.a();};NREUMQ.a=window.onload;window.onload=NREUMQ.f;};NREUMQ.push(["nrfj","beacon-1.newrelic.com","5b0327a758","2035125","NFBXZUNRW0ADAkRbCQ0aYENYH0NaBgRfHRAKUEIfQVhF",0,5,new Date().getTime(),"","","","",""]);</script>
+</body>
+</html>

--- a/test/fixtures/responses/createVideo.json
+++ b/test/fixtures/responses/createVideo.json
@@ -1,0 +1,9 @@
+{
+   "statusCode":200,
+   "statusText":"Ok",
+   "data":{
+      "videoId":"130416_36ed6e37013655a14b2b857cdccec99db72adcaa",
+      "jsonUrl":"http:\/\/www.webpagetest.org\/video\/view.php?f=json&id=130416_36ed6e37013655a14b2b857cdccec99db72adcaa",
+      "userUrl":"http:\/\/www.webpagetest.org\/video\/view.php?id=130416_36ed6e37013655a14b2b857cdccec99db72adcaa"
+   }
+}

--- a/test/fixtures/responses/embeddedVideoPlayer.html
+++ b/test/fixtures/responses/embeddedVideoPlayer.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script type="text/javascript">var NREUMQ=NREUMQ||[];NREUMQ.push(["mark","firstbyte",new Date().getTime()]);</script>
+<title>WebPagetest - Visual Comparison - Apr 30, 2013 : , </title>
+                        <link rel="stylesheet" href="/video/video-js.3.2.0/video-js.min.css" type="text/css">
+        <style type="text/css">
+            div.content
+            {
+                text-align:center;
+                background-color: black;
+                color: white;
+                font-family: arial,sans-serif
+            }
+            .link
+            {
+                text-decoration: none;
+                color: white;
+            }
+            #player
+            {
+                margin-left: auto;
+                margin-right: auto;
+            }
+            #location {
+                text-align: left;
+                padding: 5px;
+                width: 100%;
+            }
+            .vjs-default-skin .vjs-controls {height: 0;}
+            .vjs-default-skin .vjs-mute-control {display: none;}
+            .vjs-default-skin .vjs-volume-control {display: none;}
+            body {background-color: black; margin:0; padding: 0;}        </style>
+        <script type="text/javascript" src="/video/video-js.3.2.0/video.min.js"></script>
+    </head>
+    <body>
+        <div class="page">
+            <script>
+_V_.options.techOrder = ['flash', 'html5'];
+_V_.options.flash.swf = '/video/player/flowplayer-3.2.16.swf';
+_V_.options.flash.flashVars = {config:"{'clip':{'scaling':'fit'},'plugins':{'controls':{'volume':false,'mute':false,'stop':true,'tooltips':{'buttons':true,'fullscreen':'Enter fullscreen mode'}}},'canvas':{'backgroundColor':'#000000','backgroundGradient':'none'},'playlist':[{'url':'/results/video/13/04/16/36ed6e37013655a14b2b857cdccec99db72adcaa/video.png'},{'url':'/results/video/13/04/16/36ed6e37013655a14b2b857cdccec99db72adcaa/video.mp4','autoPlay':false,'autoBuffering':false}]}"};
+_V_.options.flash.params = {
+                       allowfullscreen: 'true',
+                       wmode: 'transparent',
+                       allowscriptaccess: 'always'
+                   };
+                   _V_.options.flash.attributes={};
+</script>
+<video id="player" class="video-js vjs-default-skin" controls
+                  preload="auto" width="816" height="384" poster="/results/video/13/04/16/36ed6e37013655a14b2b857cdccec99db72adcaa/video.png"data-setup="{}">
+                    <source src="/results/video/13/04/16/36ed6e37013655a14b2b857cdccec99db72adcaa/video.mp4" type='video/mp4'>
+                </video>
+                    </div>
+    <script type="text/javascript">if(!NREUMQ.f){NREUMQ.f=function(){NREUMQ.push(["load",new Date().getTime()]);var e=document.createElement("script");e.type="text/javascript";e.src=(("http:"===document.location.protocol)?"http:":"https:")+"//"+"d1ros97qkrwjf5.cloudfront.net/42/eum/rum.js";document.body.appendChild(e);if(NREUMQ.a)NREUMQ.a();};NREUMQ.a=window.onload;window.onload=NREUMQ.f;};NREUMQ.push(["nrfj","beacon-1.newrelic.com","5b0327a758","2035125","NFBXZUNRW0ADAkRbCQ0aYENYH0NaBgRfHRAKUEIfQVhF",0,5,new Date().getTime(),"","","","",""]);</script>
+</body>
+</html>

--- a/test/helpers/nock-server.js
+++ b/test/helpers/nock-server.js
@@ -32,6 +32,8 @@ var reqResMap = {
   '/getgzip.php?test=120816_V2_2&file=1_screen.png': 'screenshotFullResolution.png',
   '/cancelTest.php?test=120816_V2_2': 'cancel.html',
   '/cancelTest.php?test=120816_V2_3': 'cancelNotCancelled.html',
+  '/video/create.php?tests=130416_YS_KD4-r%3A3-c%3A1%2C130416_W6_KEE-r%3A8-c%3A1&f=json&end=visual': 'createVideo.json',
+  '/video/view.php?embed=1&id=130416_36ed6e37013655a14b2b857cdccec99db72adcaa': 'embeddedVideoPlayer.html',
 
   // test results for multi runs with/without custom median metric
   '/xmlResult.php?test=130619_KK_6A2': 'testResultsMultiRunsDefaultMedianMetric.xml',

--- a/test/helpers/response-objects.js
+++ b/test/helpers/response-objects.js
@@ -9,7 +9,7 @@ var fs = require('fs'),
 
 var PATH_OBJECTS = path.join(__dirname, '../fixtures/objects');
 
-var reExtensions = /^\.(?:json|txt)$/i,
+var reExtensions = /^\.(?:json|txt|html)$/i,
     reJSONExt = /^\.json$/i,
     reEOFNewLine = /\s+$/;
 

--- a/test/nock-test.js
+++ b/test/nock-test.js
@@ -246,6 +246,22 @@ describe('Example WebPageTest', function() {
       });
     });
 
+    it('creates a video', function (done) {
+      wpt.createVideo('130416_YS_KD4-r:3-c:1,130416_W6_KEE-r:8-c:1', {}, function (err, data) {
+        if (err) throw err;
+        assert.deepEqual(data, ResponseObjects.createVideo);
+        done();
+      });
+    });
+
+    it('get the url of an embedded video', function (done){
+      wpt.getEmbedVideoPlayer('130416_36ed6e37013655a14b2b857cdccec99db72adcaa', {}, function (err, data) {
+        if (err) throw err;
+        assert.equal(data, ResponseObjects.embeddedVideoPlayer + "\n");
+        done();
+      });
+    });
+
     // not found / invalid
 
     it('gets an invalid test status request then returns a not found test status object', function(done) {


### PR DESCRIPTION
- createVideo method create a video from tests. 
- getEmbedVideoPlayer method create a html5 player for a video.

For instance, calling `createVideo` with this parameter : 130416_YS_KD4-r:3-c:1,130416_W6_KEE-r:8-c:1 create a comparison video between the first view of the run 3 of the test 130416_YS_KD4 and the first view of the run 8 of the test 1,130416_W6_KEE.

In result, the method returns a video id, for instance : 130416_36ed6e37013655a14b2b857cdccec99db72adcaa

Then, calling `getEmbedVideoPlayer` with this video id returns a HTML5 embedded player. 
