### PR TITLE
quick fix for windows compatibility

### DIFF
--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -148,7 +148,7 @@ function api(pathname, callback, query, options) {
   }
 
   pathname = url.format({
-    pathname: path.join(config.pathname, pathname),
+    pathname: url.resolve(config.pathname, pathname),
     query: query
   });
 


### PR DESCRIPTION
Hello,

I've been using this module on Windows, but I had to make a quick change first. Please deny with extreme prejudice if this has catastrophic effects that I haven't discovered yet.

Default behavior:

```
c:\>webpagetest -s http://localhost:9080 locations -d
{
  "url": "http://localhost:9080/\\getLocations.php"
}
c:\>webpagetest -s http://localhost:9080 locations
{
  "error": {
    "name": "WPTAPIError",
    "code": 400,
    "message": "Bad Request"
  }
}
```

New behavior:

```
c:\>webpagetest -s http://localhost:9080 locations -d
{
  "url": "http://localhost:9080/getLocations.php"
}
c:\>webpagetest -s http://localhost:9080 locations
{
  "response": {
    "statusCode": 200,
    "statusText": "Ok",
    "data": {
      "location": [
        {
...
```
