### PR TITLE
Modifying regex to allow for new connection types

### DIFF
--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -16,7 +16,7 @@ var http    = require('http'),
     mapping = require('./mapping');
 
 var reSpace = /\s/,
-    reConnectivity = /^(?:DSL|FIOS|Dial|custom)$/,
+    reConnectivity = /^(?:DSL|FIOS|Dial|3G|3GFast|Native|custom)$/,
     reHTMLOutput = /<h\d[^<]*>([^<]+)<\/h\d>/; // for H3 on cancelTest.php
 
 var paths = {


### PR DESCRIPTION
The WebPageTest API allows for additional connection types that are not currently included in the regex. See: https://sites.google.com/a/webpagetest.org/docs/advanced-features/webpagetest-restful-apis.

This PR just adds the ability to request those connection types (3G, 3GFast and Native).
