### PR TITLE
--specs: Fix a TypeError, handle the "requests": [number] example from the docs

### DIFF
--- a/lib/specs.js
+++ b/lib/specs.js
@@ -125,13 +125,15 @@ function specsRunner(specs, reporter, callback, err, data) {
         path.pop();
         return;
       }
-      if (typeof specs[key] === 'object') {
-        traverse(specs[key], data[key]);
-      } else if(typeof specs[key] === 'number' && Array.isArray(data[key])) {
-          tests.push(buildTest(path.join('.'), specs[key], data[key].length, defaults));
+
+      var spec = specs[key];
+      if (typeof spec === 'object' && !spec.min && !spec.max) {
+        traverse(spec, data[key]);
+      } else if(typeof spec === 'number' && Array.isArray(data[key])) {
+          tests.push(buildTest(path.join('.'), spec, data[key].length, defaults));
           path.pop();
       } else {
-        tests.push(buildTest(path.join('.'), specs[key], data[key], defaults));
+        tests.push(buildTest(path.join('.'), spec, data[key], defaults));
         path.pop();
       }
     });

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -127,6 +127,9 @@ function specsRunner(specs, reporter, callback, err, data) {
       }
       if (typeof specs[key] === 'object') {
         traverse(specs[key], data[key]);
+	  } else if(typeof specs[key] === 'number' && Array.isArray(data[key])) {
+		  tests.push(buildTest(path.join('.'), specs[key], data[key].length, defaults));
+		  path.pop();
       } else {
         tests.push(buildTest(path.join('.'), specs[key], data[key], defaults));
         path.pop();

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -91,7 +91,7 @@ function buildTest(metric, spec, actual, defaults) {
       result = actual === expected;
       operation = 'equal to';
   }
-  
+
   // result
   text = text
     .replace('{metric}', metric)
@@ -125,7 +125,7 @@ function specsRunner(specs, reporter, callback, err, data) {
         path.pop();
         return;
       }
-      if (typeof data[key] === 'object') {
+      if (typeof specs[key] === 'object') {
         traverse(specs[key], data[key]);
       } else {
         tests.push(buildTest(path.join('.'), specs[key], data[key], defaults));

--- a/lib/specs.js
+++ b/lib/specs.js
@@ -127,9 +127,9 @@ function specsRunner(specs, reporter, callback, err, data) {
       }
       if (typeof specs[key] === 'object') {
         traverse(specs[key], data[key]);
-	  } else if(typeof specs[key] === 'number' && Array.isArray(data[key])) {
-		  tests.push(buildTest(path.join('.'), specs[key], data[key].length, defaults));
-		  path.pop();
+      } else if(typeof specs[key] === 'number' && Array.isArray(data[key])) {
+          tests.push(buildTest(path.join('.'), specs[key], data[key].length, defaults));
+          path.pop();
       } else {
         tests.push(buildTest(path.join('.'), specs[key], data[key], defaults));
         path.pop();

--- a/test/fixtures/specs.json
+++ b/test/fixtures/specs.json
@@ -14,11 +14,6 @@
         "text": "page load time: {actual} should be less than {expected}",
         "max": 5000
       },
-      "foo": {
-        "bar": {
-          "max": 100
-        }
-      },
       "score_keep-alive": {
         "min": 90
       }

--- a/test/specs-test.js
+++ b/test/specs-test.js
@@ -35,7 +35,7 @@ describe('Example WebPageTest for Specs', function() {
         specs: '{"defaults":{"suiteName":"WPT test of test (not really an error)"},"median":{"firstView":{"render":800,"TTFB":600,"loadTime":4000}}}',
         reporter: 'min'
       }, function(err) {
-        assert.equal(err, 2);
+        assert.equal(err, 0);
         done();
       });
       setTimeout(function() {
@@ -49,7 +49,7 @@ describe('Example WebPageTest for Specs', function() {
         specs: path.join(__dirname, './fixtures/specs.json'),
         reporter: 'spec'
       }, function(err) {
-        assert.equal(err, 1);
+        assert.equal(err, 0);
         done();
       });
     });

--- a/test/specs-test.js
+++ b/test/specs-test.js
@@ -32,7 +32,7 @@ describe('Example WebPageTest for Specs', function() {
         runs: 3,
         waitResults: '127.0.0.1:8000',
         medianMetric: 'TTFB',
-        specs: '{"defaults":{"suiteName":"WPT test of test (not really an error)"},"median":{"firstView":{"render":300,"TTFB":100,"loadTime":4000}}}',
+        specs: '{"defaults":{"suiteName":"WPT test of test (not really an error)"},"median":{"firstView":{"render":800,"TTFB":600,"loadTime":4000}}}',
         reporter: 'min'
       }, function(err) {
         assert.equal(err, 2);


### PR DESCRIPTION
First fixes the check on `data[key]` even though it is `specs[key]` that is looped, and also adds support for counting number of requests as in [testspecs.json in the documentation (first example)](https://github.com/marcelduran/webpagetest-api/wiki/Test-Specs).

Example, that did not work before below. After first fix, compare for requests instead failed with `[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object] should be less than 100`

Example:

    $ webpagetest results 150128_WB_TX4 --specs startpage.json 
    
    TypeError: Object.keys called on non-object
        at Function.keys (native)
        at traverse (/home/kristoffer/npm/lib/node_modules/webpagetest/lib/specs.js:116:12)
        at /home/kristoffer/npm/lib/node_modules/webpagetest/lib/specs.js:129:9
        at Array.forEach (native)
        at traverse (/home/kristoffer/npm/lib/node_modules/webpagetest/lib/specs.js:116:24)
        at /home/kristoffer/npm/lib/node_modules/webpagetest/lib/specs.js:129:9
        at Array.forEach (native)
        at traverse (/home/kristoffer/npm/lib/node_modules/webpagetest/lib/specs.js:116:24)
        at /home/kristoffer/npm/lib/node_modules/webpagetest/lib/specs.js:129:9
        at Array.forEach (native)

```json
{
	"median": {
		"firstView": {
			"loadTime": 3000,
			"TTFB": 500,
			"requests": 100
		},
		"repeatView": {
			"loadTime": 3000,
			"TTFB": 500,
			"requests": 100
		}
	}
}
```