### PR TITLE
Choose which run to use as median

### DIFF
--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -528,6 +528,12 @@ var options = {
       param: 'metric',
       info: 'set the metric used to calculate median for multiple runs tests [loadTime]'
     },
+    'medianRun': {
+      name: 'medianRun',
+      api: 'medianRun',
+      param: 'metric',
+      info: 'set the run used for median for multiple runs tests [median]'
+    },
     'specs': {
       name: 'specs',
       key: 'S',

--- a/test/fixtures/command-line/help-results.txt
+++ b/test/fixtures/command-line/help-results.txt
@@ -11,7 +11,7 @@
     -p, --pagespeed             include the PageSpeed score in the response (may be slower)
     -R, --requests              include the request data in the response (slower and results in much larger responses)
     -m, --median <metric>       set the metric used to calculate median for multiple runs tests [loadTime]
+    --medianRun <metric>        set the run used for median for multiple runs tests [median]
     -S, --specs <json_or_file>  set the specs for performance test suite
     -r, --reporter <name>       set performance test suite reporter output: [dot]|spec|tap|xunit|list|progress|min|nyan|landing|json|doc|markdown|teamcity
     -e, --request <id>          echo request ID, useful to track asynchronous requests
-

--- a/test/fixtures/command-line/help-test.txt
+++ b/test/fixtures/command-line/help-test.txt
@@ -70,6 +70,6 @@
         --pagespeed               include the PageSpeed score in the response (may be slower)
         --requests                include the request data in the response (slower and results in much larger responses)
         --median <metric>         set the metric used to calculate median for multiple runs tests [loadTime]
+        --medianRun <metric>      set the run used for median for multiple runs tests [median]
         --specs <json_or_file>    set the specs for performance test suite
         --reporter <name>         set performance test suite reporter output: [dot]|spec|tap|xunit|list|progress|min|nyan|landing|json|doc|markdown|teamcity
-


### PR DESCRIPTION
Choose which run to use as median, making it possible to actually choose the fastest of the runs to make test less independent of time spent in backend as explained by Pat http://calendar.perfplanet.com/2015/working-on-chrome-performance-with-webpagetest/