### PR TITLE
Resolving HTTP/s issue (following redirects)

### DIFF
--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -5,8 +5,7 @@
  * Released under the MIT License
  */
 
-var http    = require('http'),
-    https   = require('https'),
+var https   = require('https'),
     url     = require('url'),
     path    = require('path'),
     zlib    = require('zlib'),
@@ -57,7 +56,7 @@ var filenames = {
 
 // GET helper function
 function get(config, pathname, proxy, callback, encoding) {
-  var protocol = (config.protocol === 'https:' ? https : http),
+  var protocol = https,
       options;
 
   if (proxy) {
@@ -97,7 +96,7 @@ function get(config, pathname, proxy, callback, encoding) {
 
     if (statusCode !== 200) {
       callback(
-        new helper.WPTAPIError(statusCode, http.STATUS_CODES[statusCode])
+        new helper.WPTAPIError(statusCode, https.STATUS_CODES[statusCode])
       );
     } else {
       data = [];
@@ -316,7 +315,7 @@ function runTest(what, options, callback) {
   query[reSpace.test(what) ? 'script' : 'url'] = what;
   // set dummy url when scripting, needed when webdriver script
   if (query.script) {
-    query.url = 'http://www.webpagetest.org';
+    query.url = 'https://www.webpagetest.org';
   }
   helper.setQuery(mapping.commands.test, options, query);
 
@@ -391,7 +390,7 @@ function runTest(what, options, callback) {
 
   function listener() {
     query.pingback = url.format({
-      protocol: 'http',
+      protocol: 'https',
       hostname: options.waitResults.hostname,
       port: options.waitResults.port,
       pathname: '/testdone'
@@ -436,7 +435,7 @@ function runTest(what, options, callback) {
 
     listen = listener.bind(this);
 
-    server = http.createServer(function(req, res) {
+    server = https.createServer(function(req, res) {
       var uri = url.parse(req.url, true);
 
       res.statusCode = 204;
@@ -733,7 +732,7 @@ function WebPageTest(server, key) {
 // Allow global config override
 WebPageTest.paths = paths;
 WebPageTest.filenames = filenames;
-WebPageTest.defaultServer = 'http://www.webpagetest.org';
+WebPageTest.defaultServer = 'https://www.webpagetest.org';
 WebPageTest.defaultListenPort = 7791;
 WebPageTest.defaultWaitResultsPort = 8000;
 


### PR DESCRIPTION
As the WPT API has removed http functionality and are enforcing redirects to https, I simply removed http option to resolve the issues of node's http/s get functions not following redirects. 

#77 