### PR TITLE
Switched default public API URL to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ webpagetest --help
 ### Options
 
 #### Common (works for all commands)
-* **-s, --server** _\<server\>_: the WPT server URL [http://www.webpagetest.org]
+* **-s, --server** _\<server\>_: the WPT server URL [https://www.webpagetest.org]
 * **-d, --dryrun**: just return the RESTful API URL
 * **-o, --out** _\<file\>_: place the output into \<file\>. Defaults to stdout
 

--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -733,7 +733,7 @@ function WebPageTest(server, key) {
 // Allow global config override
 WebPageTest.paths = paths;
 WebPageTest.filenames = filenames;
-WebPageTest.defaultServer = 'http://www.webpagetest.org';
+WebPageTest.defaultServer = 'https://www.webpagetest.org';
 WebPageTest.defaultListenPort = 7791;
 WebPageTest.defaultWaitResultsPort = 8000;
 

--- a/test/helpers/nock-server.js
+++ b/test/helpers/nock-server.js
@@ -83,7 +83,7 @@ function WebPageTestMockServer(host) {
     return new WebPageTestMockServer(host);
   }
 
-  server = nock(host || 'http://www.webpagetest.org');
+  server = nock(host || 'https://www.webpagetest.org');
   nock.enableNetConnect();
 
   // request/response mapping


### PR DESCRIPTION
www.webpagetest.org moved to https yesterday and for users that use the public API but don't specify a server explicitly it started returning errors because the default http library in Node doesn't follow redirects automatically.

Longer-term it would probably be good to either add direct support for following redirects or use the request module instead.

Fixed #77