### PR TITLE
Fix batch to run with more than 2 commands at a time

### DIFF
--- a/bin/webpagetest
+++ b/bin/webpagetest
@@ -217,7 +217,7 @@ function parseBatch(filename) {
 
 function batch(file) {
   var accErr = 0,
-      count = 2,
+      count = 0,
       originalFormatData = formatData,
       originalOutput = output;
 
@@ -246,6 +246,7 @@ function batch(file) {
   if (!cmds) {
     return;
   }
+  count = cmds.length;
   output = function(){};
 
   cmds.forEach(function(cmd, index) {

--- a/test/command-line-test.js
+++ b/test/command-line-test.js
@@ -329,6 +329,7 @@ describe('WebPageTest Command Line', function() {
       data = JSON.parse(data);
       assert.equal(data[0].url, wptServer + 'testStatus.php?test=120816_V2_2');
       assert.equal(data[1].url, wptServer + 'jsonResult.php?test=120816_V2_2');
+      assert.equal(data[2].url, wptServer + 'getgzip.php?test=120816_V2_2&file=1_screen.jpg');
       done();
     });
   });

--- a/test/fixtures/batch.txt
+++ b/test/fixtures/batch.txt
@@ -1,2 +1,3 @@
-status 120816_V2_2 -s https://www.example.com:1234/foo/bar/ -d
-results 120816_V2_2 -s https://www.example.com:1234/foo/bar/ -d
+status 120816_V2_2 -d -s https://www.example.com:1234/foo/bar/
+results 120816_V2_2 -d -s https://www.example.com:1234/foo/bar/
+screenshot 120816_V2_2 -d -s https://www.example.com:1234/foo/bar/


### PR DESCRIPTION
Batch was hard coded to only work with 2 commands for some reason. It would just quit as soon as two of the commands responded. This should fix the issue. Updated the tests as well
