### PR TITLE
Add support for setting trace categories in Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ webpagetest test https://twitter.com/marcelduran
 ### Docker
 #### Build
 ```bash
-$ docker build -t webpagetest-api . 
+$ docker build -t webpagetest-api .
 ```
 #### Run
 ```bash
@@ -109,6 +109,7 @@ _The default WPT server can also be specified via environment variable `WEBPAGET
 * **-M, --timeline**: capture Developer Tools Timeline (Chrome only)
 * **-J, --callstack**: set between 1-5 to include the JS call stack. must be used in conjunction with timeline (increases overhead) (Chrome only)
 * **-q, --chrometrace**: capture chrome trace (about://tracing) (Chrome only)
+* **--tracecategories** _\<categories>\>_:  trace categories (when chrometrace enabled) (Chrome only)
 * **-G, --netlog**: capture Network Log (Chrome only)
 * **-Q, --datareduction**: enable data reduction on Chrome 34+ Android (Chrome only)
 * **-x, --useragent** _\<string\>_: custom user agent string (Chrome only)

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -184,6 +184,12 @@ var options = {
       bool: true,
       info: 'capture chrome trace (about://tracing) (Chrome only)'
     },
+    'tracecategories': {
+      name: 'traceCategories',
+      api: 'traceCategories',
+      param: 'categories',
+      info: 'trace categories (when chrometrace enabled) (Chrome only)'
+    },
     'netlog': {
       name: 'netLog',
       key: 'G',

--- a/test/fixtures/command-line/help-test.txt
+++ b/test/fixtures/command-line/help-test.txt
@@ -29,6 +29,7 @@
     -M, --timeline                capture Developer Tools Timeline (Chrome only)
     -J, --callstack               set between 1-5 to include the JS call stack. must be used in conjunction with timeline (increases overhead) (Chrome only)
     -q, --chrometrace             capture chrome trace (about://tracing) (Chrome only)
+        --tracecategories <categories>  trace categories (when chrometrace enabled) (Chrome only)
     -G, --netlog                  capture Network Log (Chrome only)
     -Q, --datareduction           enable data reduction on Chrome 34+ Android (Chrome only)
     -x, --useragent <string>      custom user agent string (Chrome only)


### PR DESCRIPTION
Adding set traceCategories for Chrome to hopefully get more information to solve https://github.com/WPO-Foundation/webpagetest/issues/823

One thing: 
* When I run the test locally I get a lot of errors "Local WebPageTest-API Proxy Listens to a Nock Server gets an invalid" but I got the same before my change