### PR TITLE
Fix http proxy with https server

### DIFF
--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -57,10 +57,11 @@ var filenames = {
 
 // GET helper function
 function get(config, pathname, proxy, callback, encoding) {
-  var protocol = (config.protocol === 'https:' ? https : http),
+  var protocol,
       options;
 
   if (proxy) {
+    var proxyUrl = url.parse(proxy);
     var pathForProxy = config.protocol + '//';
 
     if (config.auth) {
@@ -68,16 +69,18 @@ function get(config, pathname, proxy, callback, encoding) {
     }
 
     pathForProxy += config.hostname + ':' + config.port + pathname;
+    protocol = (proxyUrl.protocol === 'https:' ? https : http);
 
     options = {
-      host: proxy.split(':')[0],
-      port: proxy.split(':')[1],
+      host: proxyUrl.hostname,
+      port: proxyUrl.port,
       path: pathForProxy,
       headers: {
         Host: config.hostname
       }
     };
   } else {
+    protocol = (config.protocol === 'https:' ? https : http);
     options = {
       path: pathname,
       host: config.hostname,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=0.10.1"
   },
   "dependencies": {
-    "commander": "^2.9.0",
+    "commander": "2.10.0",
     "csv": "^1.1.1",
     "entities": "^1.1.1",
     "mocha": "^3.4.1",

--- a/test/proxy-test.js
+++ b/test/proxy-test.js
@@ -7,13 +7,14 @@
 
 var assert          = require('assert'),
     http            = require('http'),
+    https            = require('https'),
     url             = require('url'),
     WebPageTest     = require('../lib/webpagetest'),
     NockServer      = require('./helpers/nock-server'),
     ResponseObjects = require('./helpers/response-objects');
 
-var wptNockServer = new NockServer('http://wpt.com'),
-    wpt = new WebPageTest('wpt.com');
+var wptNockServer = new NockServer('https://wpt.com'),
+    wpt = new WebPageTest('https://wpt.com');
 
 // proxy for test on 9001 port
 http.createServer(function(req, res) {
@@ -24,7 +25,7 @@ http.createServer(function(req, res) {
     body.push(data);
   });
   req.on('end', function() {
-    var orgreq = http.request({
+    var orgreq = https.request({
       host:    req.headers.host,
       port:    requestUrl.port || 80,
       path:    requestUrl.path,
@@ -52,7 +53,7 @@ describe('Run via proxy', function() {
 
     it('gets a test status request', function(done) {
       wpt.getTestStatus('120816_V2_2', {
-        proxy: '127.0.0.1:9001'
+        proxy: 'http://127.0.0.1:9001'
       }, function (err, data) {
         if (err) return done(err);
         assert.deepEqual(data, ResponseObjects.testStatus);


### PR DESCRIPTION
Enables a client to hit an https webpagetest server instance through an http corporate proxy.