### PR TITLE
Dockerfile: make entry point absolute

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN npm install
 # Bundle app source
 COPY . /usr/src/app
 
-ENTRYPOINT [ "bin/webpagetest" ]
+ENTRYPOINT [ "/usr/src/app/bin/webpagetest" ]


### PR DESCRIPTION
The current entrypoint breaks if the workdir is changed.

Example:
```
docker run -w /mnt/foo -v $PWD/foo:/mnt/foo -it --rm firefoxtesteng/webpagetest-api
docker: Error response from daemon: oci runtime error: container_linux.go:265: starting container process caused "exec: \"bin/webpagetest\": stat bin/webpagetest: no such file or directory".
```

The following works as expected:
```
docker run --entrypoint /usr/src/app/bin/webpagetest  -w /mnt/foo -v $PWD/foo:/mnt/foo -it --rm firefoxtesteng/webpagetest-api
```