### PR TITLE
Update the 'Buffer' calls, fix the DeprecationWarning

### DIFF
--- a/bin/webpagetest
+++ b/bin/webpagetest
@@ -40,7 +40,7 @@ var formatData = function(err, data, info) {
   } else if (info) {
     encoding = info.encoding;
     if (encoding === 'binary') {
-      data = new Buffer(data, 'binary');
+      data = new Buffer.from(data, 'binary');
       type = info.type;
     } else {
       data = {type: info.type, data: data};

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -129,7 +129,7 @@ function netLogParser(data) {
 
 // Convert image (binary) into data URI (string)
 function dataURI(data) {
-  return new Buffer(data || '', 'binary').toString('base64');
+  return new Buffer.from(data || '', 'binary').toString('base64');
 }
 
 // Convert script objects into formatted string

--- a/lib/server.js
+++ b/lib/server.js
@@ -39,7 +39,7 @@ function output(callback, err, data, info) {
     code = err.code || code;
   } else if (info) {
     if (info.encoding === 'binary') {
-      data = new Buffer(data, 'binary');
+      data = new Buffer.from(data, 'binary');
       type = info.type;
     } else {
       data = {type: info.type, data: data};

--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -119,7 +119,7 @@ function get(config, pathname, proxy, agent, callback, encoding) {
 
       res.on('end', function onEnd() {
         var i, len, pos,
-            buffer = new Buffer(length),
+            buffer = new Buffer.alloc(length),
             type = (res.headers['content-type'] || '').split(';')[0];
 
         for (i = 0, len = data.length, pos = 0; i < len; i += 1) {


### PR DESCRIPTION
Fixes the DeprecationWarning
```
[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```