### PR TITLE
Deep clone the options object so we don't mutate it. See #55

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -237,6 +237,25 @@ function setQuery(map, options, query) {
   return query;
 }
 
+function deepClone(obj) {
+  var newObj, value, key;
+
+  if (typeof obj !== "object" || obj === null) {
+    return obj;
+  }
+
+  newObj = Array.isArray(obj) ? [] : {};
+
+  for (key in obj) {
+    value = obj[key];
+
+    // Recursively (deep) copy for nested objects, including arrays
+    newObj[key] = deepClone(value);
+  }
+
+  return newObj;
+}
+
 module.exports = {
   xmlToObj: xmlToObj,
   csvToObj: svToObj.bind(null, ',', false),
@@ -249,5 +268,6 @@ module.exports = {
   normalizeServer: normalizeServer,
   localhost: localhost,
   setQuery: setQuery,
-  WPTAPIError: WPTAPIError
+  WPTAPIError: WPTAPIError,
+  deepClone: deepClone
 };

--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -281,7 +281,7 @@ function getTestResults(id, options, callback) {
   var query = {test: id};
 
   callback = callback || typeof options === 'function' && options;
-  options = options === callback ? {} : options || {};
+  options = options === callback ? {} : helper.deepClone(options) || {};
   helper.setQuery(mapping.commands.results, options, query);
 
   // specs
@@ -317,8 +317,8 @@ function runTest(what, options, callback) {
   var query = {};
 
   callback = callback || options;
-  options = options === callback ? {} : options;
-
+  options = options === callback ? {} : helper.deepClone(options);
+  
   // testing url or script?
   query[reSpace.test(what) ? 'script' : 'url'] = what;
   // set dummy url when scripting, needed when webdriver script
@@ -479,7 +479,7 @@ function restartTest(id, options, callback) {
   var query = {resubmit: id};
 
   callback = callback || options;
-  options = options === callback ? undefined : options;
+  options = options === callback ? undefined : helper.deepClone(options);
 
   helper.setQuery(mapping.commands.restart, options, query);
 
@@ -490,7 +490,7 @@ function cancelTest(id, options, callback) {
   var query = {test: id};
 
   callback = callback || options;
-  options = options === callback ? undefined : options;
+  options = options === callback ? undefined : helper.deepClone(options);
 
   helper.setQuery(mapping.commands.cancel, options, query);
 


### PR DESCRIPTION
Currently, the wrapper mutates the options object when it's passed in. This means that if you're using a loop to do any bulk testing, the `pollResults` and `timeout` options exponentially increase (as the values are converted from seconds to milliseconds over and over).

This PR introduces a `deepClone` method to first clone the `options` object before altering it in anyway and should close #55.